### PR TITLE
feat(creds): uses CredentialProviderChain for creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,17 @@ for HTTP connections to Ethereum nodes on
 [Amazon Managed Blockchain](https://aws.amazon.com/managed-blockchain/).
 
 ## Installing
+
 Install and save as a dependency using NPM:
 `npm install @aws/web3-http-provider --save`
 
 ## Example
 
-This example assumes that your AWS IAM-related environment variables have been set
-previously. For example:
+This example assumes that your AWS IAM credentials have been set
+previously using one of the methods speficied in
+[Setting Credentials in Node.js](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html).
+For example, using environment variables:
+
 ```
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
@@ -29,12 +33,13 @@ web3.eth.getNodeInfo().then(console.log);
 ```
 
 You may also provide your credentials directly to the constructor arguments of a new instance of AWSHttpProvider():
+
 ```
 const Web3 = require('web3');
 const AWSHttpProvider = require('@aws/web3-http-provider');
 
 const credentials = {
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID, 
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
 }
 const endpoint = <your Amazon Managed Blockchain HTTP URL>
@@ -52,14 +57,13 @@ const ethers = require('ethers');
 const AWSHttpProvider = require('@aws/web3-http-provider');
 
 const credentials = {
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID, 
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
 }
 const endpoint = 'https://nd-NODEID.ethereum.managedblockchain.REGION.amazonaws.com';
 const baseProvider = new AWSHttpProvider(endpoint, credentials));
 let provider = new ethers.providers.Web3Provider(baseProvider);
 ```
-
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install and save as a dependency using NPM:
 ## Example
 
 This example assumes that your AWS IAM credentials have been set
-previously using one of the methods speficied in
+previously using one of the methods specified in
 [Setting Credentials in Node.js](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html).
 For example, using environment variables:
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,34 @@ const AWS = require('aws-sdk');
 const HttpProvider = require('web3-providers-http');
 const XHR2 = require('xhr2');
 
+class SsmCredentials extends AWS.Credentials {
+  constructor(httpProvider) {
+    super();
+    this.httpProvider = httpProvider;
+  }
+
+  refresh(callback) {
+    if (!callback) callback = AWS.util.fn.callback;
+
+    if ('ssmCredentials' in this.httpProvider &&
+        this.httpProvider.ssmCredentials &&
+        'accessKeyId' in this.httpProvider.ssmCredentials &&
+        'secretAccessKey' in this.httpProvider.ssmCredentials) {
+      this.accessKeyId = this.httpProvider.ssmCredentials.accessKeyId;
+      this.secretAccessKey = this.httpProvider.ssmCredentials.secretAccessKey;
+    } else {
+      callback(AWS.util.error(
+        new Error('ssmCredentials not set'),
+        { code: 'SsmCredentialsProviderFailure' }
+      ))
+      return;
+    }
+  
+    this.expired = false;
+    callback();
+  }
+}
+
 module.exports = class AWSHttpProvider extends HttpProvider {
   constructor(host, ssmCredentials) {
     super(host)
@@ -51,36 +79,35 @@ module.exports = class AWSHttpProvider extends HttpProvider {
         `ms. (i.e. your connect has timed out for whatever reason, check your provider).`, null);
     };
 
-    try {
-      const strPayload = JSON.stringify(payload);
-      const region = process.env.AWS_DEFAULT_REGION || 'us-east-1';
-      const creds =
-        'ssmCredentials' in this &&
-        'accessKeyId' in this.ssmCredentials &&
-        'secretAccessKey' in this.ssmCredentials &&
-        this.ssmCredentials;
-      const credentials = (creds && new AWS.Credentials(creds)) || new AWS.EnvironmentCredentials('AWS');
-      const endpoint = new AWS.Endpoint(self.host);
-      const req = new AWS.HttpRequest(endpoint, region);
-      req.method = request._method;
-      req.body = strPayload;
-      req.headers['host'] = request._url.host;
-      const signer = new AWS.Signers.V4(req, 'managedblockchain');
-      signer.addAuthorization(credentials, new Date());
-      request.setRequestHeader('Authorization', req.headers['Authorization']);
-      request.setRequestHeader('X-Amz-Date', req.headers['X-Amz-Date']);
-      if (process.env.AWS_SESSION_TOKEN) {
-        request.setRequestHeader('X-Amz-Security-Token', process.env.AWS_SESSION_TOKEN);
+    const region = process.env.AWS_DEFAULT_REGION || 'us-east-1';
+
+    const chain = new AWS.CredentialProviderChain();
+    chain.providers.unshift(() => new SsmCredentials(this));
+    
+    chain.resolve((err, credentials) => {
+      if (err) {
+        callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': missing AWS credentials. Check your environment variables using command 'echo $NODE_ENV' to verify credentials are set. ${err.message}`)
+        return;
       }
-      request.send(strPayload);
-    } catch (error) {
-        if (error.code == "ERR_INVALID_ARG_TYPE") {
-            callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': missing AWS credentials. Check your environment variables using command 'echo $NODE_ENV' to verify credentials are set.`)
-        } else {
-            callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': ` +
-            `${JSON.stringify(error, null, 2)}`, null);
+      try {
+        const strPayload = JSON.stringify(payload);
+        const endpoint = new AWS.Endpoint(self.host);
+        const req = new AWS.HttpRequest(endpoint, region);
+        req.method = request._method;
+        req.body = strPayload;
+        req.headers['host'] = request._url.host;
+        const signer = new AWS.Signers.V4(req, 'managedblockchain');
+        signer.addAuthorization(credentials, new Date());
+        request.setRequestHeader('Authorization', req.headers['Authorization']);
+        request.setRequestHeader('X-Amz-Date', req.headers['X-Amz-Date']);
+        if (process.env.AWS_SESSION_TOKEN) {
+          request.setRequestHeader('X-Amz-Security-Token', process.env.AWS_SESSION_TOKEN);
         }
-      
-    }
+        request.send(strPayload);
+      } catch (error) {
+        callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': ` +
+        `${JSON.stringify(error, null, 2)}`, null);
+       }
+    });
   }
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,8 @@
 To test this package, deploy an Ethereum node on Amazon Managed Blockchain.
-Create an IAM user with the appropriate permissions, then export the user's
-credentials into your environment.
+It uses the standard credentials resolution process found in
+[Setting Credentials in Node.js](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html).
+If you need to create test credentials, create an IAM user with the appropriate permissions,
+then export the user's credentials into your environment.
 
 ```
 export AWS_ACCESS_KEY_ID=...
@@ -11,11 +13,13 @@ export AWS_SESSION_TOKEN=...
 ```
 
 Then export the endpoint URL like so:
+
 ```
 export AMB_HTTP_ENDPOINT=https://nd-<node_id>.ethereum.managedblockchain.us-east-1.amazonaws.com
 ```
 
 Then run the example:
+
 ```
 npm install
 node index.js

--- a/test/ssmCredentialsTest.js
+++ b/test/ssmCredentialsTest.js
@@ -1,5 +1,6 @@
 const Web3 = require('web3');
 const AWSHttpProvider = require('@aws/web3-http-provider');
 const endpoint = process.env.AMB_HTTP_ENDPOINT
-const web3 = new Web3(new AWSHttpProvider(endpoint));
+const web3 = new Web3(new AWSHttpProvider(endpoint, {accessKeyId: 'KEY', secretAccessKey: 'SECRET'}));
+// Intentionally errors with message "The security token included in the request is invalid"
 web3.eth.getNodeInfo().then(console.log).catch(console.error);


### PR DESCRIPTION
Addresses issue #5 

- Updates the HTTP provider to use the CredentialProviderChain for credential resolution which allows for sourcing credentials from multiple sources, including a shared ini file as requested by the issue.
- Creates a custom credential provider for credentials passed in via the constructor. This custom credential provider is added to the beginning of the provider chain in order to be the highest precedence.
- Updates the documentation to reference the multiple ways to set credentials for Node.js.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
