### PR TITLE
Use AWS credentials chain instead of using AWS Access and Secret keys for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,8 @@ Install and save as a dependency using NPM:
 `npm install @aws/web3-http-provider --save`
 
 ## Example
-
-This example assumes that your AWS IAM-related environment variables have been set
-previously. For example:
-```
-export AWS_ACCESS_KEY_ID=...
-export AWS_SECRET_ACCESS_KEY=...
-
-# if your IAM credentials are temporary:
-export AWS_SESSION_TOKEN=...
-```
+The IAM credentials are checked against a credentials chain.
+If you are executing on AWS EC2, AWS Lambda or AWS ECS, the credentials chain will look for the IAM role attached.
 
 ```
 const Web3 = require('web3');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,16 @@
       "email": "effraga@amazon.com",
       "url": "https://github.com/evertonfraga"
     }
+
   ],
+  "contributors": [
+    {
+     "name": "Pravinchandra Varma",
+     "email": "pravincv@amazon.com",
+     "url": "https://github.com/pravinva"
+    }
+   
+  ], 
   "license": "LGPL-3.0-or-later",
   "dependencies": {
     "aws-sdk": "^2.809.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using the aws credentials chain is a more comprehensive and secure way of providing IAM credentials to the nodejs app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
