### PR TITLE
Upgrade Signature Version 4 handlers to use AWS SDK V3 methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ export AWS_SESSION_TOKEN=...
 ```
 
 ```
-const Web3 = require('web3');
-const AWSHttpProvider = require('@aws/web3-http-provider');
-const endpoint = 'https://nd-NODEID.ethereum.managedblockchain.REGION.amazonaws.com';
-const web3 = new Web3(new AWSHttpProvider(endpoint));
+import Web3 from 'web3';
+import AWSHttpSigV4_v2Provider from './awsHttpSigV4-v2.js';
+const endpoint = process.env.AMB_HTTP_ENDPOINT
+const web3 = new Web3(new AWSHttpSigV4_v2Provider(endpoint));
 web3.eth.getNodeInfo().then(console.log);
+
 ```
 
 You may also provide your credentials directly to the constructor arguments of a new instance of AWSHttpProvider():
@@ -43,7 +44,7 @@ const credentials = {
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
 }
 const endpoint = <your Amazon Managed Blockchain HTTP URL>
-const web3 = new Web3(new AWSHttpProvider(endpoint, credentials));
+const web3 = new Web3(new AWSHttpSigV4_v2Provider(endpoint, credentials));
 web3.eth.getNodeInfo().then(console.log);
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,58 +1,33 @@
 /////////////////////////////////////////////////////
-// Authored by Carl Youngblood
+// Authored by Rafia Tapia
 // Senior Blockchain Solutions Architect, AWS
-// Adapted from web3 npm package v1.3.0
 // licensed under GNU Lesser General Public License
 // https://github.com/ethereum/web3.js
 /////////////////////////////////////////////////////
 
-const AWS = require('aws-sdk');
-const HttpProvider = require('web3-providers-http');
-const XHR2 = require('xhr2');
+import HttpProvider from 'web3-providers-http';
+import XHR2 from 'xhr2';
+import { fromEnv} from '@aws-sdk/credential-providers';
+import sigv4 from '@aws-sdk/signature-v4';
+import http from '@aws-sdk/protocol-http';
+import crypto from "@aws-crypto/sha256-js";
 
-class SsmCredentials extends AWS.Credentials {
-  constructor(httpProvider) {
-    super();
-    this.httpProvider = httpProvider;
-  }
-
-  refresh(callback) {
-    if (!callback) callback = AWS.util.fn.callback;
-
-    if ('ssmCredentials' in this.httpProvider &&
-        this.httpProvider.ssmCredentials &&
-        'accessKeyId' in this.httpProvider.ssmCredentials &&
-        'secretAccessKey' in this.httpProvider.ssmCredentials) {
-      this.accessKeyId = this.httpProvider.ssmCredentials.accessKeyId;
-      this.secretAccessKey = this.httpProvider.ssmCredentials.secretAccessKey;
-    } else {
-      callback(AWS.util.error(
-        new Error('ssmCredentials not set'),
-        { code: 'SsmCredentialsProviderFailure' }
-      ))
-      return;
-    }
-  
-    this.expired = false;
-    callback();
-  }
-}
-
-module.exports = class AWSHttpProvider extends HttpProvider {
-  constructor(host, ssmCredentials) {
-    super(host)
-    this.ssmCredentials = ssmCredentials || {};
+export default class AWSHttpSigV4_v2Provider extends HttpProvider {
+  constructor(connectionStr) {
+    super(connectionStr);
   }
 
   send(payload, callback) {
-    const self = this;
+    
+    const self = this; 
+    /* ******************** XHR2 *************************** */
     const request = new XHR2(); // eslint-disable-line
-
     request.timeout = self.timeout;
     request.open('POST', self.host, true);
     request.setRequestHeader('Content-Type', 'application/json');
-
+    
     request.onreadystatechange = () => {
+
       if (request.readyState === 4 && request.timeout !== 1) {
         let result = request.responseText; // eslint-disable-line
         let error = null; // eslint-disable-line
@@ -63,51 +38,50 @@ module.exports = class AWSHttpProvider extends HttpProvider {
           let message;
           if (!!result && !!result.error && !!result.error.message) {
             message = `[aws-ethjs-provider-http] ${result.error.message}`;
-          } else  {
+          } else {
             message = `[aws-ethjs-provider-http] Invalid JSON RPC response from host provider ${self.host}: ` +
               `${JSON.stringify(result, null, 2)}`;
           }
           error = new Error(message);
         }
-
+        self.connected = true;
         callback(error, result);
       }
     };
-
     request.ontimeout = () => {
+      self.connected = false;
       callback(`[aws-ethjs-provider-http] CONNECTION TIMEOUT: http request timeout after ${self.timeout} ` +
         `ms. (i.e. your connect has timed out for whatever reason, check your provider).`, null);
     };
 
+    /* ******************** END XHR2 *************************** */
+    const strPayload = JSON.stringify(payload);
     const region = process.env.AWS_DEFAULT_REGION || 'us-east-1';
 
-    const chain = new AWS.CredentialProviderChain();
-    chain.providers.unshift(() => new SsmCredentials(this));
-    
-    chain.resolve((err, credentials) => {
-      if (err) {
-        callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': missing AWS credentials. Check your environment variables using command 'echo $NODE_ENV' to verify credentials are set. ${err.message}`)
-        return;
+    try {
+      const urlparser=new URL(self.host)
+      let signerV4 = new sigv4.SignatureV4({ credentials: fromEnv(), region: region, service: "managedblockchain", sha256: crypto.Sha256 });
+      let requestOptions={
+        protocol:urlparser.protocol,
+        hostname:urlparser.hostname,
+        method: 'POST',
+        body:strPayload,
+        headers:{'host':urlparser.host},
+        path:urlparser.pathname
+        
       }
-      try {
-        const strPayload = JSON.stringify(payload);
-        const endpoint = new AWS.Endpoint(self.host);
-        const req = new AWS.HttpRequest(endpoint, region);
-        req.method = request._method;
-        req.body = strPayload;
-        req.headers['host'] = request._url.host;
-        const signer = new AWS.Signers.V4(req, 'managedblockchain');
-        signer.addAuthorization(credentials, new Date());
-        request.setRequestHeader('Authorization', req.headers['Authorization']);
-        request.setRequestHeader('X-Amz-Date', req.headers['X-Amz-Date']);
-        if (process.env.AWS_SESSION_TOKEN) {
-          request.setRequestHeader('X-Amz-Security-Token', process.env.AWS_SESSION_TOKEN);
-        }
+      const newReq = new http.HttpRequest(requestOptions);
+      signerV4.sign(newReq,{signingDate:new Date(),}).then(signedHttpRequest => {
+        request.setRequestHeader('authorization', signedHttpRequest.headers['authorization']);
+        request.setRequestHeader('x-amz-date', signedHttpRequest.headers['x-amz-date']);
+        request.setRequestHeader('x-amz-content-sha256', signedHttpRequest.headers['x-amz-content-sha256']);
         request.send(strPayload);
-      } catch (error) {
-        callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': ` +
+      }).catch(sigError => {
+        console.log(sigError);
+      });
+    } catch (error) {
+      callback(`[aws-ethjs-provider-http] CONNECTION ERROR: Couldn't connect to node '${self.host}': ` +
         `${JSON.stringify(error, null, 2)}`, null);
-       }
-    });
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
   },
   "authors": [
     {
+      "name": "Rafia Tapia",
+      "email": "taprafia@amazon.com",
+      "url": "https://github.com/amazonrafia"
+    },
+    {
       "name": "Carl Youngblood",
       "email": "cayblood@amazon.com",
       "url": "https://github.com/cayblood"
@@ -29,8 +34,13 @@
   ],
   "license": "LGPL-3.0-or-later",
   "dependencies": {
-    "aws-sdk": "^2.809.0",
-    "web3-providers-http": "^1.3.5",
-    "xhr2": "^0.2.0"
+    "@aws-crypto/sha256-js": "^4.0.0",
+    "@aws-sdk/credential-providers": "^3.352.0",
+    "@aws-sdk/fetch-http-handler": "^3.353.0",
+    "@aws-sdk/protocol-http": "^3.347.0",
+    "@aws-sdk/signature-v4": "^3.347.0",
+    "@aws-sdk/types": "^3.347.0",
+    "web3": "^1.10.0",
+    "xhr2": "^0.2.1"
   }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Upgrade Signature Version 4 handlers to use AWS SDK V3 methods.

1. Use '@aws-sdk/signature-v4'; to construct Sigv4 headers and sign the request
2. Use '@aws-sdk/protocol-http' to create and send HTTP request 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
